### PR TITLE
Support current tokenized Smooth Streaming fragments

### DIFF
--- a/src/quantumfetcher/__init__.py
+++ b/src/quantumfetcher/__init__.py
@@ -129,6 +129,7 @@ def main(
 ):
     if (
         path is None
+        and videolist_path == Path("data/videoList.rmdj")
         and not dump_videolist_path
         and not patch_videolist
         and not build_videolist_path

--- a/src/quantumfetcher/__init__.py
+++ b/src/quantumfetcher/__init__.py
@@ -116,6 +116,14 @@ def main(
             help="Comma-seperated list of text bitrates to download",
         ),
     ] = None,
+    fragment_workers: Annotated[
+        int,
+        typer.Option(
+            help="Concurrent fragment download workers (1-16)",
+            min=1,
+            max=16,
+        ),
+    ] = 8,
     show_formats: Annotated[
         bool,
         typer.Option(
@@ -175,6 +183,7 @@ def main(
         audio_bitrates=audio_bitrates.split(",") if audio_bitrates else None,
         text_langs=text_languages.split(",") if text_languages else None,
         text_bitrates=text_bitrates.split(",") if text_bitrates else None,
+        fragment_workers=fragment_workers,
         show_formats=show_formats,
         extract_subtitles=extract_subtitles,
     )

--- a/src/quantumfetcher/downloader.py
+++ b/src/quantumfetcher/downloader.py
@@ -1,5 +1,7 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import re
 import time
+import threading
 from math import ceil
 from pathlib import Path
 
@@ -66,18 +68,43 @@ class Downloader:
         TimeRemainingColumn(),
     )
 
-    __progress_group = Group(__progress_overall, __progress_stream, __progress_media)
+    __progress_fragment = Progress(
+        SpinnerColumn(finished_text="\u2713"),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+    )
+
+    __progress_group = Group(
+        __progress_overall, __progress_stream, __progress_media, __progress_fragment
+    )
     __request_timeout = 30
 
-    def __init__(self):
-        self.__session = requests.Session()
-        self.__session.headers.update({"User-Agent": USER_AGENT})
+    def __init__(self, fragment_workers: int = 8):
+        self.__fragment_workers = max(1, min(fragment_workers, 16))
+        self.__thread_local = threading.local()
+        self.__session = self.__create_session()
+
+    def __create_session(self):
+        session = requests.Session()
+        session.headers.update({"User-Agent": USER_AGENT})
 
         retries = Retry(total=10, backoff_factor=3)
 
         adapter = HTTPAdapter(max_retries=retries)
-        self.__session.mount("http://", adapter)
-        self.__session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
+    def __get_fragment_session(self):
+        session = getattr(self.__thread_local, "session", None)
+        if session is None:
+            session = self.__create_session()
+            self.__thread_local.session = session
+        return session
 
     def __fetch_file(self, url: str) -> str:
         headers = self.__session.headers.copy()  # type: ignore
@@ -116,6 +143,7 @@ class Downloader:
         self.__streams_audio = audio_streams
         self.__streams_text = text_streams
         self.__extract_subtitles = extract_subtitles
+        self.__fragment_workers = max(1, min(self.__fragment_workers, 16))
 
         with Live(self.__progress_group, refresh_per_second=10):
             task_id = self.__progress_overall.add_task(
@@ -393,36 +421,70 @@ class Downloader:
         client_manifest_path = episode_path / "manifest"
         client_manifest.save(client_manifest_path, streams_to_download)
 
-        task_id = self.__progress_stream.add_task(
-            f"Downloading fragment files for {episode_id}...",
-            total=len(streams_to_download),
-        )
+        fragment_jobs = []
+        stream_fragment_counts = {}
 
-        for stream in streams_to_download:
+        for stream_index, stream in enumerate(streams_to_download):
             fragment_paths = client_manifest.get_fragment_paths(stream)
+            stream_fragment_counts[stream_index] = len(fragment_paths)
 
             for fragment_path in fragment_paths:
                 media_url = self.__video_list.get_fragment_url(
                     episode_id, fragment_path.as_posix()
                 )
-                self.__download_fragment(media_url, episode_path / fragment_path)
+                fragment_jobs.append(
+                    (stream_index, media_url, episode_path / fragment_path)
+                )
 
-            self.__progress_stream.update(task_id, advance=1)
+        task_id = self.__progress_stream.add_task(
+            f"Downloading fragment files for {episode_id}...",
+            total=len(streams_to_download),
+        )
 
-        self.__progress_stream.remove_task(task_id)
+        fragment_task = self.__progress_fragment.add_task(
+            f"Downloading fragments for {episode_id}...",
+            total=len(fragment_jobs),
+        )
+
+        try:
+            with ThreadPoolExecutor(max_workers=self.__fragment_workers) as executor:
+                futures = {
+                    executor.submit(self.__download_fragment, media_url, output_path): stream_index
+                    for stream_index, media_url, output_path in fragment_jobs
+                }
+
+                stream_remaining = dict(stream_fragment_counts)
+
+                for future in as_completed(futures):
+                    stream_index = futures[future]
+                    future.result()
+
+                    self.__progress_fragment.update(fragment_task, advance=1)
+
+                    stream_remaining[stream_index] -= 1
+                    if stream_remaining[stream_index] == 0:
+                        self.__progress_stream.update(task_id, advance=1)
+        finally:
+            self.__progress_fragment.remove_task(fragment_task)
+            self.__progress_stream.remove_task(task_id)
 
     def __download_fragment(self, media_url: str, output_path: Path):
         if output_path.exists() and output_path.stat().st_size > 0:
             return
 
         output_path.parent.mkdir(exist_ok=True, parents=True)
+        temp_path = output_path.with_name(output_path.name + ".part")
 
-        progress_media = self.__progress_media.add_task(
+        if temp_path.exists():
+            temp_path.unlink()
+
+        progress_media = self.__progress_fragment.add_task(
             f"Downloading {output_path.name}..."
         )
 
         try:
-            with self.__session.get(
+            session = self.__get_fragment_session()
+            with session.get(
                 media_url,
                 stream=True,
                 timeout=self.__request_timeout,
@@ -430,18 +492,20 @@ class Downloader:
                 r.raise_for_status()
                 content_length = int(r.headers.get("Content-Length", "0"))
                 if content_length:
-                    self.__progress_media.update(progress_media, total=content_length)
+                    self.__progress_fragment.update(progress_media, total=content_length)
 
-                with open(output_path, "wb") as f:
+                with open(temp_path, "wb") as f:
                     for chunk in r.iter_content(chunk_size=1024 * 64):
                         if not chunk:
                             continue
 
                         f.write(chunk)
-                        self.__progress_media.update(progress_media, advance=len(chunk))
+                        self.__progress_fragment.update(progress_media, advance=len(chunk))
+
+            temp_path.replace(output_path)
         except RequestException:
-            if output_path.exists():
-                output_path.unlink()
+            if temp_path.exists():
+                temp_path.unlink()
             raise
         finally:
-            self.__progress_media.remove_task(progress_media)
+            self.__progress_fragment.remove_task(progress_media)

--- a/src/quantumfetcher/downloader.py
+++ b/src/quantumfetcher/downloader.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
-from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ChunkedEncodingError, RequestException
 from rich.console import Group
 from rich.live import Live
 from rich.progress import (
@@ -67,6 +67,7 @@ class Downloader:
     )
 
     __progress_group = Group(__progress_overall, __progress_stream, __progress_media)
+    __request_timeout = 30
 
     def __init__(self):
         self.__session = requests.Session()
@@ -74,13 +75,15 @@ class Downloader:
 
         retries = Retry(total=10, backoff_factor=3)
 
-        self.__session.mount("http://", HTTPAdapter(max_retries=retries))
+        adapter = HTTPAdapter(max_retries=retries)
+        self.__session.mount("http://", adapter)
+        self.__session.mount("https://", adapter)
 
     def __fetch_file(self, url: str) -> str:
         headers = self.__session.headers.copy()  # type: ignore
         headers["Accept-Encoding"] = "deflate"
 
-        r = requests.get(url, headers=headers)
+        r = self.__session.get(url, headers=headers, timeout=self.__request_timeout)
         r.raise_for_status()
 
         return r.content.decode()
@@ -126,7 +129,7 @@ class Downloader:
 
     def __get_episode_manifests(
         self, episode_id
-    ) -> tuple[ClientManifest, ServerManifest]:
+    ) -> tuple[ClientManifest, ServerManifest | None]:
         episode_manifests = self.__manifests[episode_id]
         client_manifest = episode_manifests[ManifestType.Client]
 
@@ -135,7 +138,10 @@ class Downloader:
                 f"Expected ClientManifest for episode {episode_id}, got {type(client_manifest)}"
             )
 
-        server_manifest = episode_manifests[ManifestType.Server]
+        server_manifest = episode_manifests.get(ManifestType.Server)
+        if server_manifest is None:
+            return client_manifest, None
+
         if not isinstance(server_manifest, ServerManifest):
             raise TypeError(
                 f"Expected ServerManifest for episode {episode_id}, got {type(server_manifest)}"
@@ -154,6 +160,16 @@ class Downloader:
             streams_to_download.extend(streams)
 
         client_manifest, server_manifest = self.__get_episode_manifests(episode_id)
+
+        if server_manifest is None:
+            self.__download_episode_fragments(
+                episode_id,
+                episode_path,
+                streams_to_download,
+                client_manifest,
+            )
+            return
+
         client_manifest_path = server_manifest.get_client_manifest_path()
 
         if client_manifest_path is None:
@@ -269,6 +285,9 @@ class Downloader:
     def __download_stream(self, episode_id, episode_path, stream, stream_type, chunks):
         _, server_manifest = self.__get_episode_manifests(episode_id)
 
+        if server_manifest is None:
+            return
+
         if stream_type == StreamType.Video:
             stream = server_manifest.get_video_stream(stream.bitrate)
         else:
@@ -315,7 +334,7 @@ class Downloader:
             f"Downloading {outputPath.name}..."
         )
 
-        with requests.head(mediaUrl) as r:
+        with self.__session.head(mediaUrl, timeout=self.__request_timeout) as r:
             r.raise_for_status()
             contentLength = int(r.headers["Content-Length"])
 
@@ -342,7 +361,10 @@ class Downloader:
 
                 try:
                     with self.__session.get(
-                        mediaUrl, headers=headers, stream=True
+                        mediaUrl,
+                        headers=headers,
+                        stream=True,
+                        timeout=self.__request_timeout,
                     ) as r:
                         r.raise_for_status()
 
@@ -360,3 +382,66 @@ class Downloader:
                     )
                     time.sleep(1)
                     continue
+
+    def __download_episode_fragments(
+        self,
+        episode_id: str,
+        episode_path: Path,
+        streams_to_download: list,
+        client_manifest: ClientManifest,
+    ):
+        client_manifest_path = episode_path / "manifest"
+        client_manifest.save(client_manifest_path, streams_to_download)
+
+        task_id = self.__progress_stream.add_task(
+            f"Downloading fragment files for {episode_id}...",
+            total=len(streams_to_download),
+        )
+
+        for stream in streams_to_download:
+            fragment_paths = client_manifest.get_fragment_paths(stream)
+
+            for fragment_path in fragment_paths:
+                media_url = self.__video_list.get_fragment_url(
+                    episode_id, fragment_path.as_posix()
+                )
+                self.__download_fragment(media_url, episode_path / fragment_path)
+
+            self.__progress_stream.update(task_id, advance=1)
+
+        self.__progress_stream.remove_task(task_id)
+
+    def __download_fragment(self, media_url: str, output_path: Path):
+        if output_path.exists() and output_path.stat().st_size > 0:
+            return
+
+        output_path.parent.mkdir(exist_ok=True, parents=True)
+
+        progress_media = self.__progress_media.add_task(
+            f"Downloading {output_path.name}..."
+        )
+
+        try:
+            with self.__session.get(
+                media_url,
+                stream=True,
+                timeout=self.__request_timeout,
+            ) as r:
+                r.raise_for_status()
+                content_length = int(r.headers.get("Content-Length", "0"))
+                if content_length:
+                    self.__progress_media.update(progress_media, total=content_length)
+
+                with open(output_path, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=1024 * 64):
+                        if not chunk:
+                            continue
+
+                        f.write(chunk)
+                        self.__progress_media.update(progress_media, advance=len(chunk))
+        except RequestException:
+            if output_path.exists():
+                output_path.unlink()
+            raise
+        finally:
+            self.__progress_media.remove_task(progress_media)

--- a/src/quantumfetcher/flow.py
+++ b/src/quantumfetcher/flow.py
@@ -18,7 +18,7 @@ from quantumfetcher.video_list import VideoList
 class Flow:
 
     def __init__(self, interactive: bool, video_list: VideoList, **kwargs) -> None:
-        self.__downloader = Downloader()
+        self.__downloader = Downloader(fragment_workers=kwargs["fragment_workers"])
 
         self.__interactive = interactive
         self.__video_list = video_list
@@ -32,6 +32,7 @@ class Flow:
         self.__fetch_audio_bitrates: list[str] | None = kwargs["audio_bitrates"]
         self.__fetch_text_langs: list[str] | None = kwargs["text_langs"]
         self.__fetch_text_bitrates: list[str] | None = kwargs["text_bitrates"]
+        self.__fragment_workers: int = kwargs["fragment_workers"]
 
         show_formats = kwargs["show_formats"]
         extract_subtitles = kwargs["extract_subtitles"]

--- a/src/quantumfetcher/flow.py
+++ b/src/quantumfetcher/flow.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import humanreadable as hr
 from rich.console import Console
 from rich.progress import Progress
+from requests.exceptions import RequestException
 from rich.table import Table
 
 from quantumfetcher.downloader import Downloader
@@ -93,6 +94,15 @@ class Flow:
                 episodes.items(),
                 description="Fetching manifests...",
             ):
+                if (
+                    episode_id == "J1 - 4K Test"
+                    and self.__episodes_to_fetch != ["J1 - 4K Test"]
+                ):
+                    progress.console.log(
+                        "[yellow]Warning:[/yellow] Skipping dead test episode entry: J1 - 4K Test."
+                    )
+                    continue
+
                 server_manifest_url = self.__video_list.get_server_manifest_url(
                     episode_id
                 )
@@ -110,15 +120,25 @@ class Flow:
                     f"Fetching server manifest for episode {episode_id}..."
                 )
 
-                server_manifest = self.__downloader.fetch_manifest(
-                    manifest_type=ManifestType.Server,
-                    manifest_url=server_manifest_url,
-                )
+                try:
+                    server_manifest = self.__downloader.fetch_manifest(
+                        manifest_type=ManifestType.Server,
+                        manifest_url=server_manifest_url,
+                    )
+                except RequestException as exc:
+                    progress.console.log(
+                        f"[yellow]Warning:[/yellow] Server manifest for episode {episode_id} could not be fetched ({exc}). "
+                        "Will use client-manifest fragment download mode."
+                    )
+                    server_manifest = None
 
-                self.__manifests[episode_id] = {
+                episode_manifests = {
                     ManifestType.Client: client_manifest,
-                    ManifestType.Server: server_manifest,
                 }
+                if server_manifest is not None:
+                    episode_manifests[ManifestType.Server] = server_manifest
+
+                self.__manifests[episode_id] = episode_manifests
 
     def __prepare_streams(self):
         qualities = get_streams(self.__manifests)

--- a/src/quantumfetcher/manifests/client.py
+++ b/src/quantumfetcher/manifests/client.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 from quantumfetcher.dataclasses.stream import ClientStream
 from quantumfetcher.dataclasses.stream_audio import AudioStream
@@ -139,6 +140,51 @@ class ClientManifest(BaseManifest):
             return int(stream.attributes.get("Chunks"))  # type: ignore
         else:
             return -1
+
+    def get_fragment_paths(self, stream_to_fetch) -> list[Path]:
+        if isinstance(stream_to_fetch, VideoStream):
+            stream_type = StreamType.Video
+            track_name = None
+        elif isinstance(stream_to_fetch, AudioStream):
+            stream_type = StreamType.Audio
+            track_name = stream_to_fetch.name
+        elif isinstance(stream_to_fetch, TextStream):
+            stream_type = StreamType.Text
+            track_name = stream_to_fetch.name
+        else:
+            raise TypeError(f"Unsupported stream type: {type(stream_to_fetch)}")
+
+        stream_index = None
+        for stream in self.__streams:
+            expected_type = stream_type.value if stream_type != StreamType.Text else "text"
+            if stream.attributes.get("Type") != expected_type:
+                continue
+
+            if track_name and stream.attributes.get("Name") != track_name:
+                continue
+
+            stream_index = stream
+            break
+
+        if stream_index is None:
+            return []
+
+        url_template = stream_index.attributes.get("Url")
+        if not url_template:
+            return []
+
+        fragment_paths = []
+        start_time = 0
+
+        for chunk_duration in stream_index.chunks:
+            relative_path = (
+                url_template.replace("{bitrate}", str(stream_to_fetch.bitrate))
+                .replace("{start time}", str(start_time))
+            )
+            fragment_paths.append(Path(relative_path))
+            start_time += chunk_duration
+
+        return fragment_paths
 
     def save(self, path, streams) -> None:
         root = ET.Element("SmoothStreamingMedia", attrib=self.__headers)

--- a/src/quantumfetcher/video_list.py
+++ b/src/quantumfetcher/video_list.py
@@ -120,3 +120,10 @@ class VideoList:
     def get_media_url(self, episode_id, filename) -> str:
         base_path = self.get_server_manifest_url(episode_id).rsplit("/", 1)[0]
         return f"{base_path}/{filename}"
+
+    def get_fragment_url(self, episode_id: str, fragment_path: str) -> str:
+        client_manifest_url = self.__videoList.get(episode_id)
+        if not client_manifest_url:
+            raise ValueError(f"No client manifest URL found for episode {episode_id}")
+
+        return client_manifest_url.replace("manifest", fragment_path, 1)


### PR DESCRIPTION
## Summary
- Add a fallback path for the current Xbox/Akamai Smooth Streaming CDN where the legacy full server manifest endpoint returns 404/403.
- Download selected streams as tokenized Smooth Streaming fragment files using the client manifest URL templates.
- Save a filtered local client manifest alongside downloaded fragments for QuantumStreamer.
- Add request timeouts, HTTPS adapter setup, skip the dead `J1 - 4K Test` entry during normal downloads, and avoid prompting for a game root when `--videolist-path` is explicitly provided.

## Why
The existing downloader expects the old full `.ism` server manifest/media files to be reachable. At least for current Quantum Break Steam installs, client manifests and individual fragments are still reachable, but the derived server manifest URL returns 404. This makes the current release unusable for fetching episodes from the live CDN.

## Testing
- `python -m compileall src`
- `python -m quantumfetcher --videolist-path E:\SteamLibrary\steamapps\common\QuantumBreak\data\videoList_original.rmdj --episodes J1A --show-formats`
- Downloaded J1A test episode at 360p + English audio/subtitles into a scratch folder: 2,253 fragment files, ~139 MB.

Companion PR needed in QuantumStreamer so it can serve saved fragment files directly.